### PR TITLE
test: fix import path for local pytest

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Ensure package root is importable
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+


### PR DESCRIPTION
Add tests/conftest.py to include package root on sys.path so `pytest` works without package install. No code changes. CI remains green.